### PR TITLE
remove PWP::Encoding prereq from dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -38,7 +38,6 @@ tag_regexp = ^(\d+\.\d+\.\d+)$
 
 [Prereqs]
 Pod::Elemental::Transformer::List = 0
-Pod::Weaver::Plugin::Encoding = 0
 Software::License = 0
 App::Prove = 0
 autodie = 0


### PR DESCRIPTION
PWP::Encoding still shows up as a requirement on [MetaCPAN](https://metacpan.org/requires/distribution/Pod-Weaver-Plugin-Encoding?sort=[[2,1]]). This should fix it.

Thanks!
